### PR TITLE
Fix layout issues when drawer is opened

### DIFF
--- a/client/src/components/Editor.js
+++ b/client/src/components/Editor.js
@@ -16,6 +16,7 @@ import type { Args } from '../store/environment/actions';
 
 const styles = () => ({
   editor: {
+    flexGrow: 1,
     gridArea: 'editor',
   },
   errorMarker: {

--- a/client/src/components/Output.js
+++ b/client/src/components/Output.js
@@ -23,6 +23,7 @@ import {
 
 const styles = () => ({
   output: {
+    flex: 1,
     gridArea: 'output',
     flexGrow: 1,
     '& #output > .ace_gutter': {

--- a/client/src/components/PersistentDrawer.js
+++ b/client/src/components/PersistentDrawer.js
@@ -137,10 +137,12 @@ class PersistentDrawer extends React.Component<Props, State> {
 
   handleDrawerOpen = () => {
     this.setState({ open: true });
+    setTimeout(() => window.dispatchEvent(new Event('resize')), 195);
   };
 
   handleDrawerClose = () => {
     this.setState({ open: false });
+    setTimeout(() => window.dispatchEvent(new Event('resize')), 195);
   };
 
   handleChangeAnchor = event => {

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -16,9 +16,8 @@ const styles = () => ({
   },
   '@media only screen and (min-width: 600px)': {
     container: {
-      gridTemplateColumns: '1fr 1fr',
-      gridTemplateRows: '1fr',
-      gridTemplateAreas: "'editor output'",
+      display: 'flex',
+      flexDirection: 'row',
     },
   },
 });


### PR DESCRIPTION
* Use flexbox to set even spacing between editor and output when drawer is opened
* Fix editor code being pushed under the header component

Before:
<img width="913" alt="screen shot 2018-04-18 at 10 58 10 am" src="https://user-images.githubusercontent.com/8571671/38949495-6845e516-42f7-11e8-987f-404ad0c839dd.png">

After:
<img width="913" alt="screen shot 2018-04-18 at 10 57 32 am" src="https://user-images.githubusercontent.com/8571671/38949505-6d2b22bc-42f7-11e8-9d5b-4e9df0031047.png">
